### PR TITLE
Command.help.reworked

### DIFF
--- a/commands/bonk.js
+++ b/commands/bonk.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'bonk',
     description: 'Give another use the bonk',
+    permissions: 'User',
+    disabled: false,
     execute(message, args, client, commandFiles, staffCommandFiles, Discord, config) {
         let target = message.mentions.users.first();
         let targetMember = message.guild.members.cache.get(target.id);

--- a/commands/help.js
+++ b/commands/help.js
@@ -5,7 +5,7 @@ module.exports = {
     description: "Displays all command aliases and descriptions.",
     execute(message, args, client, commandFiles, staffCommandFiles, Discord) {
         const argsFirst = args.toString();
-        let supportedCommands = ['ping'];
+        let supportedCommands = [];
         commandFiles.forEach(element => {
             commandTitle = element.substring(0, element.length-3);
             supportedCommands.push(commandTitle);

--- a/commands/help.js
+++ b/commands/help.js
@@ -69,6 +69,8 @@ module.exports = {
         let name = client.commands.get(args[0]).name;
         let description = client.commands.get(args[0]).description;
         let permissions = client.commands.get(args[0]).permissions;
+
+        if (commandObject.disabled === true) return message.reply('This command is disabled');
         let commandMethods = Object.getOwnPropertyNames(commandObject).filter(element => {
             return typeof commandObject[element] === 'function';
         })

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'help',
     description: "Displays all command aliases and descriptions.",
+    permissions: 'User',
+    disabled: false,
     execute(message, args, client, commandFiles, staffCommandFiles, Discord) {
         const argsFirst = args.toString();
         let supportedCommands = [];
@@ -16,17 +18,17 @@ module.exports = {
         const helpEmbed = new Discord.MessageEmbed()
 
         if (args[0] === undefined) {
-            this.empty(message, helpEmbed, commandFiles);
+            this.empty(message, helpEmbed, commandFiles, client);
         }
         else if (args[0] === 'admin') {
-            this.admin(message, helpEmbed, staffCommandFiles);   
+            this.admin(message, helpEmbed, staffCommandFiles, client);   
         }
         else if (supportedCommands.includes(argsFirst)) {
-            this.anyCommand(message, helpEmbed, argsFirst)
+            this.anyCommand(message, helpEmbed, args, argsFirst, client)
         }
         else message.reply("Unrecognized Argument");
     },
-    empty(message, helpEmbed, commandFiles) {
+    empty(message, helpEmbed, commandFiles, client) {
         helpEmbed.setTitle('Currently Supported Commands:')
             .setColor('#2BFF78');
 
@@ -42,7 +44,7 @@ module.exports = {
             }); 
             message.channel.send(helpEmbed);
     },
-    admin(message, helpEmbed, staffCommandFiles) {
+    admin(message, helpEmbed, staffCommandFiles, client) {
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You do not have sufficient permissions to perform this command');
                 
         helpEmbed.setTitle('Currently Supported Commands:')
@@ -61,11 +63,12 @@ module.exports = {
          });
         message.channel.send(helpEmbed);
     },
-    anyCommand(message, helpEmbed, argsFirst) {
+    anyCommand(message, helpEmbed, args, argsFirst, client) {
         let commandObject = client.commands.get(argsFirst);
 
         let name = client.commands.get(args[0]).name;
         let description = client.commands.get(args[0]).description;
+        let permissions = client.commands.get(args[0]).permissions;
         let commandMethods = Object.getOwnPropertyNames(commandObject).filter(element => {
             return typeof commandObject[element] === 'function';
         })
@@ -82,7 +85,8 @@ module.exports = {
         .addFields({
             name: 'Available Arguments:', 
             value: commandArgs
-        });
+        })
+        .setFooter(`Required Permission Level: ${permissions}`)
 
         message.channel.send(helpEmbed);
     }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,15 +1,22 @@
+const ping = require("./ping");
 
 module.exports = {
     name: 'help',
     description: "Displays all command aliases and descriptions.",
     execute(message, args, client, commandFiles, staffCommandFiles, Discord) {
-        const supportedCommands = client.commands;
+        const argsFirst = args.toString();
+        let supportedCommands = ['ping'];
+        commandFiles.forEach(element => {
+            commandTitle = element.substring(0, element.length-3);
+            supportedCommands.push(commandTitle);
+        });
+        console.log(supportedCommands);
 
         const helpEmbed = new Discord.MessageEmbed()
-        .setTitle('Currently Supported Commands:')
 
         if (args[0] === undefined) {
-            helpEmbed.setColor('#2BFF78');
+            helpEmbed.setTitle('Currently Supported Commands:')
+            .setColor('#2BFF78');
 
             commandFiles.forEach(element => {
                 let modifiedElement = element.substring(0, element.length-3);
@@ -26,7 +33,8 @@ module.exports = {
         else if (args[0] === 'admin') {
             if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You do not have sufficient permissions to perform this command');
                 
-            helpEmbed.setColor('#FF502B')
+            helpEmbed.setTitle('Currently Supported Commands:')
+            .setColor('#FF502B')
             .setDescription('Admin Specific Commands');                    
 
             staffCommandFiles.forEach(element => {
@@ -34,21 +42,35 @@ module.exports = {
 
                 let name = client.commands.get(modifiedElement).name;
                 let description = client.commands.get(modifiedElement).description;
-                helpEmbed.addFields(
-                    {name: name, value: description}
-                );
+                helpEmbed.addFields({
+                    name: name,
+                    value: description
+                });
              });
             message.channel.send(helpEmbed);
         }
-        else if (supportedCommands.contains(args[0])) {
+        else if (supportedCommands.includes(argsFirst)) {
             let name = client.commands.get(args[0]).name;
             let description = client.commands.get(args[0]).description;
-            let commandArgs = client.commands.get(name).args;
+            let commandMethods = Object.getOwnPropertyNames(argsFirst).filter(element => {
+                return typeof argsFirst[element] === 'function';
+            })
 
-            helpEmbed.addFields({
-                name: name, 
-                value: description
+            let commandArgs = commandMethods.filter(method => method.name === 'execute');
+
+            if (!commandArgs.length) {
+                commandArgs = 'This Command Has No Arguments!';
+            }
+            console.log(commandArgs);
+            helpEmbed.setTitle(name)
+            .setColor('#2BFF78')
+            .setDescription(description)
+            .addFields({
+                name: 'Available Arguments:', 
+                value: commandArgs
             });
+
+            message.channel.send(helpEmbed);
         }
         else message.reply("Unrecognized Argument");
     }

--- a/commands/help.js
+++ b/commands/help.js
@@ -16,7 +16,18 @@ module.exports = {
         const helpEmbed = new Discord.MessageEmbed()
 
         if (args[0] === undefined) {
-            helpEmbed.setTitle('Currently Supported Commands:')
+            this.empty(message, helpEmbed, commandFiles);
+        }
+        else if (args[0] === 'admin') {
+            this.admin(message, helpEmbed, staffCommandFiles);   
+        }
+        else if (supportedCommands.includes(argsFirst)) {
+            this.anyCommand(message, helpEmbed, argsFirst)
+        }
+        else message.reply("Unrecognized Argument");
+    },
+    empty(message, helpEmbed, commandFiles) {
+        helpEmbed.setTitle('Currently Supported Commands:')
             .setColor('#2BFF78');
 
             commandFiles.forEach(element => {
@@ -30,51 +41,49 @@ module.exports = {
                 });
             }); 
             message.channel.send(helpEmbed);
-        }
-        else if (args[0] === 'admin') {
-            if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You do not have sufficient permissions to perform this command');
+    },
+    admin(message, helpEmbed, staffCommandFiles) {
+        if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You do not have sufficient permissions to perform this command');
                 
-            helpEmbed.setTitle('Currently Supported Commands:')
-            .setColor('#FF502B')
-            .setDescription('Admin Specific Commands');                    
+        helpEmbed.setTitle('Currently Supported Commands:')
+        .setColor('#FF502B')
+        .setDescription('Admin Specific Commands');                    
 
-            staffCommandFiles.forEach(element => {
-                let modifiedElement = element.substring(0, element.length-3);
+        staffCommandFiles.forEach(element => {
+            let modifiedElement = element.substring(0, element.length-3);
 
-                let name = client.commands.get(modifiedElement).name;
-                let description = client.commands.get(modifiedElement).description;
-                helpEmbed.addFields({
-                    name: name,
-                    value: description
-                });
-             });
-            message.channel.send(helpEmbed);
-        }
-        else if (supportedCommands.includes(argsFirst)) {
-            let commandObject = client.commands.get(argsFirst);
-
-            let name = client.commands.get(args[0]).name;
-            let description = client.commands.get(args[0]).description;
-            let commandMethods = Object.getOwnPropertyNames(commandObject).filter(element => {
-                return typeof commandObject[element] === 'function';
-            })
-
-            let commandArgs = commandMethods.filter(method => method !== 'execute');
-            console.log(commandArgs);
-            if (!commandArgs.length) {
-                commandArgs = 'This Command Has No Arguments!';
-            }
-
-            helpEmbed.setTitle(name)
-            .setColor('#2BFF78')
-            .setDescription(description)
-            .addFields({
-                name: 'Available Arguments:', 
-                value: commandArgs
+            let name = client.commands.get(modifiedElement).name;
+            let description = client.commands.get(modifiedElement).description;
+            helpEmbed.addFields({
+                name: name,
+                value: description
             });
+         });
+        message.channel.send(helpEmbed);
+    },
+    anyCommand(message, helpEmbed, argsFirst) {
+        let commandObject = client.commands.get(argsFirst);
 
-            message.channel.send(helpEmbed);
+        let name = client.commands.get(args[0]).name;
+        let description = client.commands.get(args[0]).description;
+        let commandMethods = Object.getOwnPropertyNames(commandObject).filter(element => {
+            return typeof commandObject[element] === 'function';
+        })
+
+        let commandArgs = commandMethods.filter(method => method !== 'execute');
+        
+        if (!commandArgs.length) {
+            commandArgs = 'This Command Has No Arguments!';
         }
-        else message.reply("Unrecognized Argument");
+
+        helpEmbed.setTitle(name)
+        .setColor('#2BFF78')
+        .setDescription(description)
+        .addFields({
+            name: 'Available Arguments:', 
+            value: commandArgs
+        });
+
+        message.channel.send(helpEmbed);
     }
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,5 +1,3 @@
-const ping = require("./ping");
-
 module.exports = {
     name: 'help',
     description: "Displays all command aliases and descriptions.",
@@ -10,7 +8,10 @@ module.exports = {
             commandTitle = element.substring(0, element.length-3);
             supportedCommands.push(commandTitle);
         });
-        console.log(supportedCommands);
+        staffCommandFiles.forEach(element => {
+            commandTitle = element.substring(0, element.length-3);
+            supportedCommands.push(commandTitle);
+        })
 
         const helpEmbed = new Discord.MessageEmbed()
 
@@ -50,18 +51,20 @@ module.exports = {
             message.channel.send(helpEmbed);
         }
         else if (supportedCommands.includes(argsFirst)) {
+            let commandObject = client.commands.get(argsFirst);
+
             let name = client.commands.get(args[0]).name;
             let description = client.commands.get(args[0]).description;
-            let commandMethods = Object.getOwnPropertyNames(argsFirst).filter(element => {
-                return typeof argsFirst[element] === 'function';
+            let commandMethods = Object.getOwnPropertyNames(commandObject).filter(element => {
+                return typeof commandObject[element] === 'function';
             })
 
-            let commandArgs = commandMethods.filter(method => method.name === 'execute');
-
+            let commandArgs = commandMethods.filter(method => method !== 'execute');
+            console.log(commandArgs);
             if (!commandArgs.length) {
                 commandArgs = 'This Command Has No Arguments!';
             }
-            console.log(commandArgs);
+
             helpEmbed.setTitle(name)
             .setColor('#2BFF78')
             .setDescription(description)

--- a/commands/mcserver.js
+++ b/commands/mcserver.js
@@ -4,6 +4,8 @@ const Rcon = require("rcon");
 module.exports = {
     name: 'mcserver',
     description: "An array of commands for interacting with the minecraft server.",
+    permissions: 'User',
+    disabled: false,
     execute(message, args) {
         const acceptedArgs = ['ip', 'help', 'start'];
         if (!args.length) return message.channel.send('This command requires arguments!  Type "?mcserver help" for a list of supported arguments');

--- a/commands/mcserver.js
+++ b/commands/mcserver.js
@@ -5,7 +5,7 @@ module.exports = {
     name: 'mcserver',
     description: "An array of commands for interacting with the minecraft server.",
     permissions: 'User',
-    disabled: false,
+    disabled: true,
     execute(message, args) {
         const acceptedArgs = ['ip', 'help', 'start'];
         if (!args.length) return message.channel.send('This command requires arguments!  Type "?mcserver help" for a list of supported arguments');

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'ping',
     description: "Displays bot online status.",
+    permissions: "User",
+    disabled: false,
     execute(message, args){
         message.channel.send('All systems working!');
     }

--- a/commands/staff/info.js
+++ b/commands/staff/info.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'info',
     description: 'An array of commands which provides info about me.',
+    permissions: 'Staff',
+    disabled: false,
     execute(message, args, client, commandFiles, staffCommandFiles, Discord, config, version) {
 
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');

--- a/commands/staff/info.js
+++ b/commands/staff/info.js
@@ -1,15 +1,18 @@
 module.exports = {
     name: 'info',
     description: 'An array of commands which provides info about me.',
-    execute(message, args, client, commandFiles, staffCommandFiles, Discord, config) {
+    execute(message, args, client, commandFiles, staffCommandFiles, Discord, config, version) {
 
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');
 
         
         if (!args.length) return message.reply('This command requires arguments!');
         else if (args[0] === 'version') {
-            message.channel.send(`The bot is currently on: ${config.version}`);
+            this.version(message, version);
         }
         else return message.channel.send('Unrecognized arguments');
+    },
+    version(message, version) {
+        message.channel.send(`The bot is currently on: ${version}`);
     }
 }

--- a/commands/staff/jail.js
+++ b/commands/staff/jail.js
@@ -3,6 +3,8 @@ const { User, Role, ReactionUserManager } = require("discord.js");
 module.exports = {
     name: 'jail',
     description: 'Banishes a user to the horny gulag',
+    permissions: "Staff",
+    disabled: false,
     execute(message, args) {
 
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');

--- a/commands/staff/log.js
+++ b/commands/staff/log.js
@@ -3,6 +3,8 @@ const fs = require("fs");
 module.exports = {
     name: 'log',
     description: "An array of commands for admins to interact with bot logs.",
+    permissions: "Staf",
+    disabled: false,
     execute(message, args) {
 
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');

--- a/commands/staff/log.js
+++ b/commands/staff/log.js
@@ -4,20 +4,28 @@ module.exports = {
     name: 'log',
     description: "An array of commands for admins to interact with bot logs.",
     execute(message, args) {
-        const dateObj = new Date();
-        const seconds = dateObj.getSeconds();
 
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');
 
         if (args[0] === "view") {
-            message.channel.send({ files: ["./recentlog.txt"]});
+            this.view(message);
         }
         else if (args[0] === "clear") {
-            fs.writeFile('recentLog.txt', `[ ${seconds} ]s user: ${message.author} cleared the log \r\n`, function (err) {
-                if (err) return console.log(err);
-            });
-            message.channel.send('Log Cleared!');
+            this.clear(message);
         }
         else return message.channel.send('This command requires arguments!');
+    },
+    view(message) {
+        message.channel.send({ files: ['./recentLog.txt']});
+        console.log('Synchronous File Upload Started; Uploading log file');
+    },
+    clear(message) {
+        const dateObj = new Date();
+        const seconds = dateObj.getSeconds();
+
+        fs.writeFile('recentLog.txt', `[ ${seconds} ]s user: ${message.author} cleared the log \r\n`, (err) => {
+            if (err) return console.log(err);
+        });
+        message.channel.send('Log Cleared!');
     }
 }

--- a/commands/staff/reaction-custom.js
+++ b/commands/staff/reaction-custom.js
@@ -3,6 +3,8 @@ const { MessageEmbed } = require("discord.js");
 module.exports = {
     name: 'reaction-custom',
     description: 'Adds a predefined embed message with reaciton role functionality',
+    permissions: "Staff",
+    disabled: false,
     async execute (message, args, client, commandFiles, staffCommandFiles, Discord) {
         
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');

--- a/commands/staff/reaction-welcome.js
+++ b/commands/staff/reaction-welcome.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'reaction-welcome',
     description: 'Adds a predefined embed message with reaciton role functionality.  (EXECUTED ON STARTUP)',
+    permissions: "Staff",
+    disabled: false,
     async execute (message, args, client, commandFiles, staffCommandFiles, Discord) {
         
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');

--- a/commands/staff/sudo.js
+++ b/commands/staff/sudo.js
@@ -1,6 +1,8 @@
 module.exports = {
     name: 'sudo',
     description: "Writes specified message under bot name.",
+    permissions: "Staff",
+    disabled: false,
     execute(message, args){
         if (!message.member.roles.cache.has('738215800778784859')) return message.reply('You have insufficient permissions to perform this command!');
 

--- a/index.js
+++ b/index.js
@@ -51,8 +51,6 @@ client.on('message', message => {
     try {
         client.commands.get(command).execute(message, args, client, commandFiles, staffCommandFiles, Discord, config, version);
         logMessage.LogMessage(command, message, args);
-
-        if (client.commands.get(command).execute() === undefined) throw 'Unrecognized Command'
     } catch(error) {
         console.error(error);
         message.reply(`Command Failed to Execute: ${error}`);

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ client.on('message', message => {
         client.commands.get(command).execute(message, args, client, commandFiles, staffCommandFiles, Discord, config, version);
         logMessage.LogMessage(command, message, args);
 
-        if (!command) throw 'Unrecognized Command'
+        if (client.commands.get(command).execute() === undefined) throw 'Unrecognized Command'
     } catch(error) {
         console.error(error);
         message.reply(`Command Failed to Execute: ${error}`);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ client.on('message', message => {
     const command = args.shift().toLowerCase();
 
     try {
-        client.commands.get(command).execute(message, args, client, commandFiles, staffCommandFiles, Discord, config);
+        client.commands.get(command).execute(message, args, client, commandFiles, staffCommandFiles, Discord, config, version);
         logMessage.LogMessage(command, message, args);
 
         if (!command) throw 'Unrecognized Command'


### PR DESCRIPTION
Reworked Help Command Functionality
- Help now supports arguments for any command within the 'commands' folder.
- Help <command> will display the name, description, arguments, and required permission level for the specified command.
- All command arguments are now refactored into methods, of which are children of the command object.
- Help will also filter out specified commands (help <command>) when the command's 'disabled' attribute is truthy. 
- General bug fixes